### PR TITLE
linux-aarch64 support

### DIFF
--- a/configure/os/CONFIG_SITE.linux-aarch64.linux-aarch64
+++ b/configure/os/CONFIG_SITE.linux-aarch64.linux-aarch64
@@ -1,0 +1,16 @@
+#
+# $Id$
+#
+# Site Specific Configuration Information
+# Only the local epics system manager should modify this file
+
+# Where to find utilities/libraries
+#       If you do not have a certain product,
+#       leave the line empty.
+#
+
+X11_LIB=/usr/lib/aarch64-linux-gnu
+X11_INC=/usr/include/X11
+MOTIF_LIB=/home/ubuntu/lesstif/lib
+MOTIF_INC=/home/ubuntu/lesstif/include
+


### PR DESCRIPTION
Tested on the RPi4 aarch64 image from https://github.com/TheRemote/Ubuntu-Server-raspi4-unofficial/releases.
Managed to compile and run medm from git master.
Had to manually compile and install lesstif from https://launchpad.net/ubuntu/+source/lesstif2/1:0.95.2-1.

![Screenshot_2020-09-22_21-30-21](https://user-images.githubusercontent.com/2725009/93940735-50d95f00-fd2d-11ea-8050-9e6f2fc90517.png)
